### PR TITLE
Custom Label Values for targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ the aggregate view. This can be modified
     	If a target metrics pages does not responde with this many miliseconds then timeout (default 1000)
     	
   -targets (TARGETS) string
-    	comma separated list of targets e.g. http://localhost:8081/metrics,http://localhost:8082/metrics
+    	comma separated list of targets e.g. http://localhost:8081/metrics,http://localhost:8082/metrics or url1=http://localhost:8081/metrics,url2=http://localhost:8082/metrics for custom label values
     	
   -targets.label (TARGETS_LABEL) bool
     	Add a label to metrics to show their origin target (default true)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -46,7 +46,7 @@ func init() {
 	serverBind = stringFlag(flag.CommandLine, "server.bind", ":8080", "Bind the HTTP server to this address e.g. 127.0.0.1:8080 or just :8080")
 
 	targetScrapeTimeout = intFlag(flag.CommandLine, "targets.scrape.timeout", 1000, "If a target metrics pages does not responde with this many miliseconds then timeout")
-	targets = stringFlag(flag.CommandLine, "targets", "", "comma separated list of targets e.g. http://localhost:8081/metrics,http://localhost:8082/metrics")
+	targets = stringFlag(flag.CommandLine, "targets", "", "comma separated list of targets e.g. http://localhost:8081/metrics,http://localhost:8082/metrics or url1=http://localhost:8081/metrics,url2=http://localhost:8082/metrics for custom label values")
 	targetLabelsEnabled = boolFlag(flag.CommandLine, "targets.label", true, "Add a label to metrics to show their origin target")
 	targetLabelName = stringFlag(flag.CommandLine, "targets.label.name", "ae_source", "Label name to use if a target name label is appended to metrics")
 
@@ -113,6 +113,7 @@ func main() {
 
 type Result struct {
 	URL          string
+	Name         string
 	SecondsTaken float64
 	MetricFamily map[string]*io_prometheus_client.MetricFamily
 	Error        error
@@ -152,7 +153,7 @@ func (f *Aggregator) Aggregate(targets []string, output io.Writer) {
 				for mfName, mf := range result.MetricFamily {
 					if *targetLabelsEnabled {
 						for _, m := range mf.Metric {
-							m.Label = append(m.Label, &io_prometheus_client.LabelPair{Name: targetLabelName, Value: &result.URL})
+							m.Label = append(m.Label, &io_prometheus_client.LabelPair{Name: targetLabelName, Value: &result.Name})
 						}
 					}
 					if existingMf, ok := allFamilies[mfName]; ok {
@@ -164,7 +165,7 @@ func (f *Aggregator) Aggregate(targets []string, output io.Writer) {
 					}
 				}
 				if *verboseFlag {
-					log.Printf("OK: %s was refreshed in %.3f seconds", result.URL, result.SecondsTaken)
+					log.Printf("OK: %s=%s was refreshed in %.3f seconds", result.Name, result.URL, result.SecondsTaken)
 				}
 			}
 		}
@@ -179,10 +180,17 @@ func (f *Aggregator) Aggregate(targets []string, output io.Writer) {
 
 func (f *Aggregator) fetch(target string, resultChan chan *Result) {
 
-	startTime := time.Now()
-	res, err := f.HTTP.Get(target)
+	s := strings.Split(target, "=")
+	url := s[0]
+	name := s[0]
+	if len(s) == 2 {
+  	url = s[1]
+  }
 
-	result := &Result{URL: target, SecondsTaken: time.Since(startTime).Seconds(), Error: nil}
+	startTime := time.Now()
+	res, err := f.HTTP.Get(url)
+
+	result := &Result{URL: url, Name: name, SecondsTaken: time.Since(startTime).Seconds(), Error: nil}
 	if res != nil {
 		result.MetricFamily, err = getMetricFamilies(res.Body)
 		if err != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -182,10 +182,10 @@ func (f *Aggregator) fetch(target string, resultChan chan *Result) {
 
 	s := strings.Split(target, "=")
 	url := s[0]
-	name := s[0]
-	if len(s) == 2 {
-  	url = s[1]
-  }
+  	name := s[0]
+  	if len(s) == 2 {
+		url = s[1]
+	}
 
 	startTime := time.Now()
 	res, err := f.HTTP.Get(url)


### PR DESCRIPTION
Add ability to set values for target labels. Example:

```
bin/prometheus-aggregate-exporter -targets="url2=http://10.218.2.230/metrics2,url1=http://10.218.2.230/metrics1,http://10.218.2.230/metrics3"
```

Result:
```
curl 127.0.0.1:8080/metrics
# HELP resolver_requests Request types sent to resolver
# TYPE resolver_requests counter
resolver_requests{resolver="blablabla",code="name",ae_source="url1"} 0
resolver_requests{resolver="blablabla",code="srv",ae_source="url1"} 0
resolver_requests{resolver="blablabla",code="addr",ae_source="url1"} 0
resolver_requests{resolver="blablabla",code="name",ae_source="url2"} 0
resolver_requests{resolver="blablabla",code="srv",ae_source="url2"} 0
resolver_requests{resolver="blablabla",code="addr",ae_source="url2"} 0
resolver_requests{resolver="blablabla",code="name",ae_source="http://10.218.2.230/metrics3"} 0
resolver_requests{resolver="blablabla",code="srv",ae_source="http://10.218.2.230/metrics3"} 0
resolver_requests{resolver="blablabla",code="addr",ae_source="http://10.218.2.230/metrics3"} 0
```