### PR TITLE
Label values regexp

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ the aggregate view. This can be modified
   -targets.label.name (TARGETS_LABEL_NAME) string
     	Label name to use if a target name label is appended to metrics (default "ae_source")
     	
+  -targets.label.regexp (TARGETS_LABEL_REGEXP) string
+    	Regexp for match metrics label values (default ".+")
+
   -targets.scrape.timeout (TARGETS_SCRAPE_TIMEOUT) int
     	If a target metrics pages does not responde with this many miliseconds then timeout (default 1000)
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"time"
 	"net"
-  "syscall"
+ 	"syscall"
 	"regexp"
 
 	"github.com/prometheus/client_model/go"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -188,6 +188,7 @@ func (f *Aggregator) Aggregate(targets []string, output io.Writer) {
 								match, _ := regexp.MatchString(*targetLabelRegexp, r.GetValue())
 								if match {
 									existingMf.Metric = append(existingMf.Metric, m)
+									break
 								}
 							}
 						}
@@ -203,8 +204,10 @@ func (f *Aggregator) Aggregate(targets []string, output io.Writer) {
 										newFamilies.Metric = newFamilies.Metric[:1]
 										newFamilies.Metric[0] = m
 										im++
+										break
 									} else {
 										newFamilies.Metric = append(newFamilies.Metric, m)
+										break
 									}
 								}
 							}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -203,7 +203,7 @@ func (f *Aggregator) Aggregate(targets []string, output io.Writer) {
 									if im == 1 {
 										newFamilies.Metric = newFamilies.Metric[:1]
 										newFamilies.Metric[0] = m
-										im = im + 1
+										im++
 									} else {
 										newFamilies.Metric = append(newFamilies.Metric, m)
 									}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -163,8 +163,6 @@ func (f *Aggregator) Aggregate(targets []string, output io.Writer) {
 
 		allFamilies := make(map[string]*io_prometheus_client.MetricFamily)
 
-		var newFamilies *io_prometheus_client.MetricFamily
-
 		for {
 			if numTargets == numResuts {
 				break
@@ -194,6 +192,7 @@ func (f *Aggregator) Aggregate(targets []string, output io.Writer) {
 							}
 						}
 					} else {
+						var newFamilies *io_prometheus_client.MetricFamily
 						im := 1
 						for _, m := range mf.Metric {
 							for _, r := range m.Label {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -201,8 +201,8 @@ func (f *Aggregator) Aggregate(targets []string, output io.Writer) {
 								if match {
 									newFamilies = mf
 									if im == 1 {
-										newFamilies.Metric = newFamilies.Metric[:1]
-										newFamilies.Metric[0] = m
+										newFamilies.Metric = nil
+										newFamilies.Metric = append(newFamilies.Metric, m)
 										im++
 										break
 									} else {


### PR DESCRIPTION
Example, **without set regexp**,
```
bin/prometheus-aggregate-exporter -targets="url2=http://10.218.2.230/metrics2,url1=http://10.218.2.230/metrics1,http://10.218.2.230/metrics3"
```

result:
```
curl 127.0.0.1:8080/metrics
# HELP resolver_requests Request types sent to resolver
# TYPE resolver_requests counter
resolver_requests{resolver="blablabla",code="name",ae_source="url1"} 0
resolver_requests{resolver="blablabla",code="srv",ae_source="url1"} 0
resolver_requests{resolver="blablabla",code="addr",ae_source="url1"} 0
resolver_requests{resolver="blablabla",code="name",ae_source="url2"} 0
resolver_requests{resolver="blablabla",code="srv",ae_source="url2"} 0
resolver_requests{resolver="blablabla",code="addr",ae_source="url2"} 0
resolver_requests{resolver="blablabla",code="name",ae_source="http://10.218.2.230/metrics3"} 0
resolver_requests{resolver="blablabla",code="srv",ae_source="http://10.218.2.230/metrics3"} 0
resolver_requests{resolver="blablabla",code="addr",ae_source="http://10.218.2.230/metrics3"} 0
```

Example, **with set regexp**,
```
bin/prometheus-aggregate-exporter -targets="url2=http://10.218.2.230/metrics2,url1=http://10.218.2.230/metrics1,http://10.218.2.230/metrics3" -targets.label.regexp "^(srv|name)$"
```

result:
```
curl 127.0.0.1:8080/metrics
# HELP resolver_requests Request types sent to resolver
# TYPE resolver_requests counter
resolver_requests{resolver="blablabla",code="name",ae_source="http://10.218.2.230/metrics3"} 0
resolver_requests{resolver="blablabla",code="srv",ae_source="http://10.218.2.230/metrics3"} 0
resolver_requests{resolver="blablabla",code="name",ae_source="url1"} 0
resolver_requests{resolver="blablabla",code="srv",ae_source="url1"} 0
resolver_requests{resolver="blablabla",code="name",ae_source="url2"} 0
resolver_requests{resolver="blablabla",code="srv",ae_source="url2"} 0
```

So, we can filter by any label value and drop not important metrics.
