### PR TITLE
Support for = in query string

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,4 +97,8 @@ the metrics will rather look like:
 
     http_requests_total{method="post",code="200",instance="histo1"} 1027 1395066363000
          
-     
+#### Target URL containing a `=` character
+
+In case one of your target urls contains a `=` character (for instance consul agent's exporter is available at `/v1/agent/metrics?format=prometheus`), you **must** use the custom labelling notation:
+
+     bin/prometheus-aggregate-exporter -targets="consul=http://localhost:8500/v1/agent/metrics?format=prometheus"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -206,8 +206,8 @@ func (f *Aggregator) fetch(target string, resultChan chan *Result) {
 	s := strings.Split(target, "=")
 	url := s[0]
 	name := s[0]
-	if len(s) == 2 {
-		url = s[1]
+	if len(s) > 1 {
+		url = strings.Join(s[1:], "=")
 	}
 
 	startTime := time.Now()


### PR DESCRIPTION
This PR allows for the code in `fetch` to support `=` in a target url (for instance `/v1/agent/metrics?format=prometheus`).

fixes #16