### PR TITLE
Use non-root user for container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,9 @@ RUN cd /src/cmd && go build -o prometheus-aggregate-exporter
 
 FROM alpine:latest
 WORKDIR /app
-COPY --from=build-env /src/cmd/prometheus-aggregate-exporter /app/
+
+ARG USER=nobody
+USER nobody
+
+COPY --from=build-env --chown=nobody /src/cmd/prometheus-aggregate-exporter /app/
 ENTRYPOINT ["./prometheus-aggregate-exporter"]


### PR DESCRIPTION
Closes #20 

This will allow to run the container as a different user than root for security reasons. It doesn't affect the main functionality
(Tested with docker-compose scrapping other 2 containers)